### PR TITLE
Add inst-bootmenu tag

### DIFF
--- a/bootloader-ofw.json
+++ b/bootloader-ofw.json
@@ -1,7 +1,8 @@
 {
   "tags": [
     "bootloader-ofw",
-    "ENV-OFW-1"
+    "ENV-OFW-1",
+    "inst-bootmenu"
   ],
   "area": [
     {


### PR DESCRIPTION
This needle can be reused for livcdreboot

Signed-off-by: Dinar Valeev dvaleev@suse.com
