### PR TITLE
no workaround in test-mysql_srv-1-lat9w-16-20160824.json

### DIFF
--- a/test-mysql_srv-1-lat9w-16-20160824.json
+++ b/test-mysql_srv-1-lat9w-16-20160824.json
@@ -1,7 +1,5 @@
 {
-  "properties": [
-    "workaround"
-  ],
+  "properties": [],
   "tags": [
     "test-mysql_srv-1"
   ],


### PR DESCRIPTION
to avoid to report test as "soft failed" in
https://openqa.opensuse.org/tests/272416#step/mysql_srv/9

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>