### PR TITLE
no workaround in desktop-selection-text-eurlatgr-20160918.json

### DIFF
--- a/desktop-selection-text-eurlatgr-20160918.json
+++ b/desktop-selection-text-eurlatgr-20160918.json
@@ -1,7 +1,5 @@
 {
-  "properties": [
-    "workaround"
-  ],
+  "properties": [],
   "area": [
     {
       "xpos": 1,


### PR DESCRIPTION
to avoid to report test as "soft failed" in
https://openqa.opensuse.org/tests/272409#step/logpackages/1

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>