### PR TITLE
Prevent mismatch of 'logged_in' on black desktop background

### DIFF
--- a/tty2-selected-logged_in-20160930.json
+++ b/tty2-selected-logged_in-20160930.json
@@ -6,7 +6,7 @@
   "area": [
     {
       "height": 341,
-      "width": 544,
+      "width": 100,
       "ypos": 0,
       "xpos": 1,
       "type": "match",


### PR DESCRIPTION
Should fix isuses like in
https://openqa.opensuse.org/tests/273970#step/terminology/10