### PR TITLE
Add test-eog-started tag to eog needles

### DIFF
--- a/42-test-eog-20150915.json
+++ b/42-test-eog-20150915.json
@@ -1,6 +1,7 @@
 {
   "tags": [
     "test-eog-1",
+    "test-eog-started",
     "ENV-DESKTOP-gnome",
     "ENV-DISTRI-opensuse",
     "ENV-INSTLANG-en_US"

--- a/42-test-eog-20160304.json
+++ b/42-test-eog-20160304.json
@@ -11,6 +11,7 @@
   ],
   "tags": [
     "test-eog-1",
+    "test-eog-started",
     "ENV-DESKTOP-gnome",
     "ENV-DISTRI-opensuse",
     "ENV-INSTLANG-en_US"

--- a/test-eog-leap422-20160708.json
+++ b/test-eog-leap422-20160708.json
@@ -11,6 +11,7 @@
   ],
   "tags": [
     "test-eog-1",
+    "test-eog-started",
     "ENV-DESKTOP-gnome",
     "ENV-DISTRI-opensuse",
     "ENV-INSTLANG-en_US"


### PR DESCRIPTION
Inspired by https://progress.opensuse.org/issues/17430

the SLE needles still need to be done (when I find them)