### PR TITLE
Proper classification for all bootloader-ofw needles

### DIFF
--- a/bootloader_ofw-20150721.json
+++ b/bootloader_ofw-20150721.json
@@ -10,6 +10,7 @@
     }
   ],
   "tags": [
+    "bootloader",
     "bootloader-ofw"
   ]
 }


### PR DESCRIPTION
Related to fixing https://openqa.suse.de/tests/805496#step/install_update/59