### PR TITLE
Rename enabledhome-partition and enabledhome-volume to enabledhome

### DIFF
--- a/partitioning_togglehome-enabledhome-partition-20180525.json
+++ b/partitioning_togglehome-enabledhome-partition-20180525.json
@@ -1,7 +1,7 @@
 {
   "tags": [
     "ENV-DISTRI-opensuse",
-    "enabledhome-partition"
+    "enabledhome"
   ],
   "area": [
     {

--- a/partitioning_togglehome-enabledhome-textmode-partition-20180526.json
+++ b/partitioning_togglehome-enabledhome-textmode-partition-20180526.json
@@ -11,6 +11,6 @@
   ],
   "tags": [
     "ENV-VIDEOMODE-text",
-    "enabledhome-partition"
+    "enabledhome"
   ]
 }

--- a/partitioning_togglehome-enabledhome-volume-20180526.json
+++ b/partitioning_togglehome-enabledhome-volume-20180526.json
@@ -11,6 +11,6 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "enabledhome-volume"
+    "enabledhome"
   ]
 }


### PR DESCRIPTION
Changes introduced in
[poo#36517](https://progress.opensuse.org/issues/36517). Shortcut
depends if we have LVM enabled, so we can use single needle to
assert if home partition/volume is enabled.