### PR TITLE
Add workaround in root-console-rpc-msg-boo1116598-20181119.json

### DIFF
--- a/root-console-rpc-msg-boo1116598-20181119.json
+++ b/root-console-rpc-msg-boo1116598-20181119.json
@@ -20,5 +20,7 @@
       "type": "match"
     }
   ],
-  "properties": []
+  "properties": [
+    "workaround"
+  ]
 }


### PR DESCRIPTION
I forgot to set it in previous creation as reported in
https://openqa.opensuse.org/tests/800841#step/shutdown_ltp/13