### PR TITLE
Change match level of gnome-screenlock-password-Tumbleweed

### DIFF
--- a/gnome-screenlock-password-Tumbleweed-20181012.json
+++ b/gnome-screenlock-password-Tumbleweed-20181012.json
@@ -5,7 +5,8 @@
       "type": "match",
       "ypos": 256,
       "width": 458,
-      "height": 263
+      "height": 263,
+      "match" : 100
     }
   ],
   "properties": [],


### PR DESCRIPTION
Raise match level of this needle. 

On https://openqa.opensuse.org/tests/824730#step/shutdown/3 , user name was wrong but it was 98% similar.