### PR TITLE
[WIP] Change tag name for separate home checkbox

### DIFF
--- a/disabledhome-20151120.json
+++ b/disabledhome-20151120.json
@@ -9,7 +9,7 @@
     }
   ],
   "tags": [
-    "disabledhome",
+    "unchecked_separate_home_checkbox",
     "ENV-DISTRI-opensuse"
   ],
   "properties": []

--- a/disabledhome-20190104.json
+++ b/disabledhome-20190104.json
@@ -10,7 +10,7 @@
   ],
   "properties": [],
   "tags": [
-    "disabledhome",
+    "unchecked_separate_home_checkbox",
     "ENV-DISTRI-opensuse"
   ]
 }

--- a/disabledhome-textmode-20170117.json
+++ b/disabledhome-textmode-20170117.json
@@ -3,7 +3,7 @@
   "tags": [
     "ENV-DESKTOP-textmode",
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ],
   "area": [
     {

--- a/disabledhome-textmode-20171117.json
+++ b/disabledhome-textmode-20171117.json
@@ -2,7 +2,7 @@
   "tags": [
     "ENV-DESKTOP-textmode",
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ],
   "area": [
     {

--- a/disabledhome-textmode-20180119.json
+++ b/disabledhome-textmode-20180119.json
@@ -12,7 +12,7 @@
   "tags": [
     "ENV-DESKTOP-textmode",
     "ENV-DISTRI-opensuse",
-    "disabledhome",
+    "unchecked_separate_home_checkbox",
     "storage-ng"
   ]
 }

--- a/partitioning_togglehome-disabledhome-20171102-1.json
+++ b/partitioning_togglehome-disabledhome-20171102-1.json
@@ -1,7 +1,7 @@
 {
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ],
   "area": [
     {

--- a/partitioning_togglehome-disabledhome-20180302.json
+++ b/partitioning_togglehome-disabledhome-20180302.json
@@ -1,7 +1,7 @@
 {
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ],
   "properties": [],
   "area": [

--- a/partitioning_togglehome-disabledhome-20180312.json
+++ b/partitioning_togglehome-disabledhome-20180312.json
@@ -11,6 +11,6 @@
   ],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-disabledhome-20190103.json
+++ b/partitioning_togglehome-disabledhome-20190103.json
@@ -11,6 +11,6 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-disabledhome-20190121.json
+++ b/partitioning_togglehome-disabledhome-20190121.json
@@ -11,6 +11,6 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-disabledhome-highlighted-20180211.json
+++ b/partitioning_togglehome-disabledhome-highlighted-20180211.json
@@ -11,6 +11,6 @@
   ],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-disabledhome-highlighted-20180302.json
+++ b/partitioning_togglehome-disabledhome-highlighted-20180302.json
@@ -11,6 +11,6 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-disabledhome-highlighted-20180309.json
+++ b/partitioning_togglehome-disabledhome-highlighted-20180309.json
@@ -1,7 +1,7 @@
 {
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ],
   "properties": [],
   "area": [

--- a/partitioning_togglehome-disabledhome-highlighted-20180316.json
+++ b/partitioning_togglehome-disabledhome-highlighted-20180316.json
@@ -11,6 +11,6 @@
   ],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-disabledhome-highlighted-20190121.json
+++ b/partitioning_togglehome-disabledhome-highlighted-20190121.json
@@ -11,6 +11,6 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "disabledhome"
+    "unchecked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-disabledhome-textmode-20180525.json
+++ b/partitioning_togglehome-disabledhome-textmode-20180525.json
@@ -12,7 +12,7 @@
   "tags": [
     "ENV-DESKTOP-textmode",
     "ENV-DISTRI-opensuse",
-    "disabledhome",
+    "unchecked_separate_home_checkbox",
     "storage-ng"
   ]
 }

--- a/partitioning_togglehome-disabledhome-textmode-20190104.json
+++ b/partitioning_togglehome-disabledhome-textmode-20190104.json
@@ -12,7 +12,7 @@
   "tags": [
     "ENV-DESKTOP-textmode",
     "ENV-DISTRI-opensuse",
-    "disabledhome",
+    "unchecked_separate_home_checkbox",
     "storage-ng"
   ]
 }

--- a/partitioning_togglehome-disabledhome-textmode-20190125.json
+++ b/partitioning_togglehome-disabledhome-textmode-20190125.json
@@ -12,7 +12,7 @@
   "tags": [
     "ENV-DESKTOP-textmode",
     "ENV-DISTRI-opensuse",
-    "disabledhome",
+    "unchecked_separate_home_checkbox",
     "storage-ng"
   ]
 }

--- a/partitioning_togglehome-enabledhome-partition-20180525.json
+++ b/partitioning_togglehome-enabledhome-partition-20180525.json
@@ -1,7 +1,7 @@
 {
   "tags": [
     "ENV-DISTRI-opensuse",
-    "enabledhome"
+    "checked_separate_home_checkbox"
   ],
   "area": [
     {

--- a/partitioning_togglehome-enabledhome-textmode-partition-20180526.json
+++ b/partitioning_togglehome-enabledhome-textmode-partition-20180526.json
@@ -11,6 +11,6 @@
   ],
   "tags": [
     "ENV-VIDEOMODE-text",
-    "enabledhome"
+    "checked_separate_home_checkbox"
   ]
 }

--- a/partitioning_togglehome-enabledhome-volume-20180726.json
+++ b/partitioning_togglehome-enabledhome-volume-20180726.json
@@ -10,7 +10,7 @@
   ],
   "tags": [
     "ENV-DISTRI-opensuse",
-    "enabledhome"
+    "checked_separate_home_checkbox"
   ],
   "properties": []
 }


### PR DESCRIPTION
The commit changes the tags to contain checked_ and unchecked_ prefixes
to use the needles in 'Element::Checkbox' class of the UI framework.

Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6901