### PR TITLE
Add generalized tag "xorg-tty" instead of partially wrong tty7

### DIFF
--- a/xorg_vt-X-20150505.json
+++ b/xorg_vt-X-20150505.json
@@ -1,5 +1,6 @@
 {
   "tags": [
+    "xorg-tty",
     "xorg-tty7"
   ],
   "properties": [],

--- a/xorg_vt-X-20160813.json
+++ b/xorg_vt-X-20160813.json
@@ -23,6 +23,7 @@
     }
   ],
   "tags": [
+    "xorg-tty",
     "xorg-tty7"
   ],
   "properties": []

--- a/xorg_vt-X-boo1138327-20190614.json
+++ b/xorg_vt-X-boo1138327-20190614.json
@@ -26,6 +26,7 @@
     "workaround"
   ],
   "tags": [
+    "xorg-tty",
     "xorg-tty7"
   ]
 }

--- a/xorg_vt-X-boo1138327-20190617.json
+++ b/xorg_vt-X-boo1138327-20190617.json
@@ -26,6 +26,7 @@
     "workaround"
   ],
   "tags": [
+    "xorg-tty",
     "xorg-tty7"
   ]
 }

--- a/xorg_vt-X-with-sddm-20150910.json
+++ b/xorg_vt-X-with-sddm-20150910.json
@@ -24,6 +24,7 @@
   ],
   "properties": [],
   "tags": [
+    "xorg-tty",
     "xorg-tty7"
   ]
 }

--- a/xorg_vt-X-with-sddm-20160813.json
+++ b/xorg_vt-X-with-sddm-20160813.json
@@ -23,6 +23,7 @@
     }
   ],
   "tags": [
+    "xorg-tty",
     "xorg-tty7"
   ],
   "properties": []

--- a/xorg_vt-Xorg-20160813.json
+++ b/xorg_vt-Xorg-20160813.json
@@ -1,5 +1,6 @@
 {
   "tags": [
+    "xorg-tty",
     "xorg-tty7",
     "ENV-DISTRI-opensuse"
   ],

--- a/xorg_vt-Xwayland-20180423.json
+++ b/xorg_vt-Xwayland-20180423.json
@@ -16,6 +16,7 @@
     }
   ],
   "tags": [
+    "xorg-tty",
     "xorg-tty7"
   ],
   "properties": []


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/53339