### PR TITLE
Prevent false matches of 'screenlock-xscreensaver'

### DIFF
--- a/screenlock-xscreensaver-20180821.json
+++ b/screenlock-xscreensaver-20180821.json
@@ -1,7 +1,8 @@
 {
   "tags": [
     "screenlock",
-    "blackscreen"
+    "blackscreen",
+    "ENV-DESKTOP-minimalx"
   ],
   "area": [
     {


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/48899