### PR TITLE
Revert "Prevent false matches of 'screenlock-xscreensaver'"

### DIFF
--- a/screenlock-xscreensaver-20180821.json
+++ b/screenlock-xscreensaver-20180821.json
@@ -1,8 +1,7 @@
 {
   "tags": [
     "screenlock",
-    "blackscreen",
-    "ENV-DESKTOP-minimalx"
+    "blackscreen"
   ],
   "area": [
     {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-needles-opensuse#633

Because it breaks a number of tests, mainly for GNOME tests on aarch64 (Tumbleweed and Leap 15.2).
See: https://progress.opensuse.org/issues/48899#note-6
