### PR TITLE
Rename tags for raid partitioning needles

### DIFF
--- a/modify_existing_partition-partitioning_raid-filesystem_ext4-20191021.json
+++ b/modify_existing_partition-partitioning_raid-filesystem_ext4-20191021.json
@@ -10,6 +10,6 @@
   ],
   "properties": [],
   "tags": [
-    "partitioning_raid-filesystem_ext4"
+    "partitioning_ext4-format-selected"
   ]
 }

--- a/partitioning_raid-fat_format-selected-20181114.json
+++ b/partitioning_raid-fat_format-selected-20181114.json
@@ -9,7 +9,7 @@
     }
   ],
   "tags": [
-    "partitioning_raid-fat_format-selected"
+    "partitioning_fat-format-selected"
   ],
   "properties": []
 }

--- a/partitioning_raid-fat_format-selected-20190125.json
+++ b/partitioning_raid-fat_format-selected-20190125.json
@@ -10,6 +10,6 @@
   ],
   "properties": [],
   "tags": [
-    "partitioning_raid-fat_format-selected"
+    "partitioning_fat-format-selected"
   ]
 }

--- a/partitioning_raid-fat_format-selected-20190318.json
+++ b/partitioning_raid-fat_format-selected-20190318.json
@@ -10,6 +10,6 @@
   ],
   "properties": [],
   "tags": [
-    "partitioning_raid-fat_format-selected"
+    "partitioning_fat-format-selected"
   ]
 }

--- a/partitioning_raid-filesystem_ext4-20181113.json
+++ b/partitioning_raid-filesystem_ext4-20181113.json
@@ -16,7 +16,7 @@
     }
   ],
   "tags": [
-    "partitioning_raid-filesystem_ext4"
+    "partitioning_ext4-format-selected"
   ],
   "properties": []
 }

--- a/partitioning_raid-filesystem_ext4-20190110.json
+++ b/partitioning_raid-filesystem_ext4-20190110.json
@@ -17,6 +17,6 @@
   ],
   "properties": [],
   "tags": [
-    "partitioning_raid-filesystem_ext4"
+    "partitioning_ext4-format-selected"
   ]
 }

--- a/partitioning_raid-filesystem_ext4-20190318.json
+++ b/partitioning_raid-filesystem_ext4-20190318.json
@@ -17,6 +17,6 @@
   ],
   "properties": [],
   "tags": [
-    "partitioning_raid-filesystem_ext4"
+    "partitioning_ext4-format-selected"
   ]
 }

--- a/partitioning_raid-swap_format-selected-20181101.json
+++ b/partitioning_raid-swap_format-selected-20181101.json
@@ -16,7 +16,7 @@
     }
   ],
   "tags": [
-    "partitioning_raid-swap_format-selected"
+    "partitioning_swap-format-selected"
   ],
   "properties": []
 }

--- a/partitioning_raid-swap_format-selected-20190115.json
+++ b/partitioning_raid-swap_format-selected-20190115.json
@@ -17,6 +17,6 @@
   ],
   "properties": [],
   "tags": [
-    "partitioning_raid-swap_format-selected"
+    "partitioning_swap-format-selected"
   ]
 }

--- a/partitioning_raid-swap_format-selected-20190306.json
+++ b/partitioning_raid-swap_format-selected-20190306.json
@@ -10,6 +10,6 @@
   ],
   "properties": [],
   "tags": [
-    "partitioning_raid-swap_format-selected"
+    "partitioning_swap-format-selected"
   ]
 }


### PR DESCRIPTION
Renaming tags for raid partitioning needles. The new tags are according to format "partitioning_%s-format-selected" in order to match the changes of pull request #9237 : https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/9237/files#diff-3a91353c18f2ab16cdd0abc6b2c927b5