### PR TITLE
Add proper exclusion tags to many "bootloader-grub2" needles

### DIFF
--- a/bootloader-grub2-krypton-20190712.json
+++ b/bootloader-grub2-krypton-20190712.json
@@ -19,6 +19,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-Krypton-Live",
+    "ENV-VERSION-Tumbleweed",
     "bootloader-grub2",
     "inst-bootmenu"
   ]

--- a/bootloader-grub2-leap150-20180427.json
+++ b/bootloader-grub2-leap150-20180427.json
@@ -1,6 +1,7 @@
 {
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.0",
     "bootloader-grub2",
     "inst-bootmenu"

--- a/bootloader-grub2-leap151-20190418.json
+++ b/bootloader-grub2-leap151-20190418.json
@@ -18,6 +18,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.1",
     "bootloader-grub2",
     "inst-bootmenu"

--- a/bootloader-grub2-leap152-20191010.json
+++ b/bootloader-grub2-leap152-20191010.json
@@ -18,6 +18,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2",
     "inst-bootmenu"

--- a/bootloader-grub2-leap152-alpha-20191210.json
+++ b/bootloader-grub2-leap152-alpha-20191210.json
@@ -25,6 +25,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2",
     "inst-bootmenu"

--- a/bootloader-grub2-leap152-beta-20200220.json
+++ b/bootloader-grub2-leap152-beta-20200220.json
@@ -25,6 +25,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2",
     "inst-bootmenu"

--- a/bootloader-grub2-leap152-beta-uefi-20200220.json
+++ b/bootloader-grub2-leap152-beta-uefi-20200220.json
@@ -26,6 +26,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2",
     "inst-bootmenu"

--- a/bootloader-grub2-leap152-xmas-alpha-20191210.json
+++ b/bootloader-grub2-leap152-xmas-alpha-20191210.json
@@ -32,7 +32,9 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
+    "CHRISTMAS",
     "bootloader-grub2",
     "inst-bootmenu"
   ]

--- a/bootloader-grub2-microos-15.2-uefi-20200424.json
+++ b/bootloader-grub2-microos-15.2-uefi-20200424.json
@@ -19,6 +19,7 @@
   "tags": [
     "ENV-DISTRI-microos",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2",
     "inst-bootmenu"

--- a/bootloader-tw-salt_installer-20190111.json
+++ b/bootloader-tw-salt_installer-20190111.json
@@ -19,6 +19,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-VERSION-Tumbleweed",
     "bootloader-grub2",
     "inst-bootmenu"
   ]

--- a/bootloader_tw-live-kde-20190709.json
+++ b/bootloader_tw-live-kde-20190709.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-VERSION-Tumbleweed",
+    "ENV-FLAVOR-KDE-Live",
     "boot-live-kde",
     "bootloader",
     "bootloader-grub2"

--- a/bootloader_tw-live-kde-20191215.json
+++ b/bootloader_tw-live-kde-20191215.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-VERSION-Tumbleweed",
+    "ENV-FLAVOR-KDE-Live",
     "boot-live-kde",
     "bootloader",
     "bootloader-grub2"

--- a/bootloader_tw-live-xfce-20190715.json
+++ b/bootloader_tw-live-xfce-20190715.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-VERSION-Tumbleweed",
+    "ENV-FLAVOR-XFCE-Live",
     "boot-live-xfce",
     "bootloader",
     "bootloader-grub2"

--- a/bootloader_uefi-gnome-next-live-20180320.json
+++ b/bootloader_uefi-gnome-next-live-20180320.json
@@ -1,5 +1,8 @@
 {
   "tags": [
+    "ENV-DISTRI-opensuse",
+    "ENV-FLAVOR-Gnome-Live",
+    "ENV-UEFI-1",
     "boot-live-gnome",
     "bootloader-grub2"
   ],

--- a/bootloader_uefi-leap150-live-gnome-20180315.json
+++ b/bootloader_uefi-leap150-live-gnome-20180315.json
@@ -1,6 +1,8 @@
 {
   "tags": [
     "boot-live-gnome",
+    "ENV-LEAP-1",
+    "ENV-VERSION-15.0",
     "bootloader-grub2"
   ],
   "properties": [],

--- a/bootloader_uefi-leap150-live-kde-20180315.json
+++ b/bootloader_uefi-leap150-live-kde-20180315.json
@@ -1,6 +1,7 @@
 {
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.0",
     "boot-live-kde",
     "bootloader-grub2"

--- a/bootloader_uefi-leap151-live-gnome-20181105.json
+++ b/bootloader_uefi-leap151-live-gnome-20181105.json
@@ -1,6 +1,7 @@
 {
   "tags": [
     "boot-live-gnome",
+    "ENV-LEAP-1",
     "bootloader-grub2"
   ],
   "properties": [],

--- a/bootloader_uefi-leap151-live-kde-20181105.json
+++ b/bootloader_uefi-leap151-live-kde-20181105.json
@@ -11,6 +11,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.1",
     "boot-live-kde",
     "bootloader-grub2"

--- a/bootloader_uefi-leap152-live-gnome-20200217.json
+++ b/bootloader_uefi-leap152-live-gnome-20200217.json
@@ -11,6 +11,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "boot-live-gnome",
     "bootloader-grub2"

--- a/bootloader_uefi-leap152-live-kde-20190903.json
+++ b/bootloader_uefi-leap152-live-kde-20190903.json
@@ -11,6 +11,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "boot-live-kde",
     "bootloader-grub2"

--- a/bootloader_uefi-leap152-live-kde-20200215.json
+++ b/bootloader_uefi-leap152-live-kde-20200215.json
@@ -11,6 +11,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-opensuse",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "boot-live-kde",
     "bootloader-grub2"

--- a/bootloader_uefi-leap152-live-rescue-20191104.json
+++ b/bootloader_uefi-leap152-live-rescue-20191104.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "boot-live-rescue",
     "bootloader-grub2"

--- a/bootloader_uefi-leap152-live-rescue-20200217.json
+++ b/bootloader_uefi-leap152-live-rescue-20200217.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "boot-live-rescue",
     "bootloader-grub2"

--- a/bootloader_uefi-rescue-live-20190715.json
+++ b/bootloader_uefi-rescue-live-20190715.json
@@ -10,6 +10,9 @@
   ],
   "properties": [],
   "tags": [
+    "ENV-DISTRI-opensuse",
+    "ENV-VERSION-Tumbleweed",
+    "ENV-FLAVOR-Rescue-CD",
     "boot-live-gnome",
     "boot-live-rescue",
     "bootloader-grub2"

--- a/bootmenu-aarch64-jeos-20190304.json
+++ b/bootmenu-aarch64-jeos-20190304.json
@@ -13,6 +13,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-AArch64",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.1",
     "bootloader-grub2"
   ]

--- a/bootmenu-aarch64-jeos-20190315.json
+++ b/bootmenu-aarch64-jeos-20190315.json
@@ -13,6 +13,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-AArch64",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.1",
     "bootloader-grub2"
   ]

--- a/bootmenu-aarch64-jeos-20200215.json
+++ b/bootmenu-aarch64-jeos-20200215.json
@@ -13,6 +13,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-AArch64",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2"
   ]

--- a/bootmenu-aarch64-jeos-20200218.json
+++ b/bootmenu-aarch64-jeos-20200218.json
@@ -13,6 +13,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-AArch64",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2"
   ]

--- a/bootmenu-aarch64-jeos-20200226.json
+++ b/bootmenu-aarch64-jeos-20200226.json
@@ -13,6 +13,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-AArch64",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "bootloader-grub2"
   ]

--- a/bootmenu-gnome-live-15.2-aarch64-20200215.json
+++ b/bootmenu-gnome-live-15.2-aarch64-20200215.json
@@ -19,6 +19,7 @@
   "tags": [
     "ENV-DISTRI-opensuse",
     "ENV-LIVECD-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "boot-live-gnome",
     "bootloader-grub2",

--- a/bootmenu-grub2-argon-20191111.json
+++ b/bootmenu-grub2-argon-20191111.json
@@ -20,6 +20,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-Argon-Live",
     "ENV-LIVECD-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.1",
     "boot-live-kde",
     "bootloader-grub2",

--- a/bootmenu-jeos-20180724.json
+++ b/bootmenu-jeos-20180724.json
@@ -12,6 +12,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-kvm",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.0",
     "bootloader-grub2"
   ],

--- a/bootmenu-jeos-leap-15.1-20181105.json
+++ b/bootmenu-jeos-leap-15.1-20181105.json
@@ -13,6 +13,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-kvm",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.1",
     "bootloader-grub2"
   ]

--- a/bootmenu-jeos-leap-15.1-20190402.json
+++ b/bootmenu-jeos-leap-15.1-20190402.json
@@ -13,6 +13,7 @@
     "ENV-DISTRI-opensuse",
     "ENV-FLAVOR-JeOS-for-kvm",
     "ENV-UEFI-1",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.1",
     "bootloader-grub2"
   ]

--- a/bootmenu-krypton-20190712.json
+++ b/bootmenu-krypton-20190712.json
@@ -12,6 +12,7 @@
   "tags": [
     "ENV-DESKTOP-kde",
     "ENV-FLAVOR-Krypton-Live",
+    "ENV-LEAP-1",
     "ENV-LIVECD-1",
     "boot-live-kde",
     "bootloader-grub2"

--- a/grub2-leap150-20190306.json
+++ b/grub2-leap150-20190306.json
@@ -10,6 +10,8 @@
   ],
   "properties": [],
   "tags": [
+    "ENV-LEAP-1",
+    "ENV-VERSION-15.0",
     "bootloader-grub2-leap150"
   ]
 }

--- a/grub2-microos-152-20200428.json
+++ b/grub2-microos-152-20200428.json
@@ -11,6 +11,7 @@
   "properties": [],
   "tags": [
     "ENV-DISTRI-microos",
+    "ENV-LEAP-1",
     "ENV-VERSION-15.2",
     "autoyast-boot",
     "bootloader",


### PR DESCRIPTION
This should help time-critical detections of the grub screen which often
has a timeout that can be missed.

Rule of thumb to all needle creators: Whenever you add a word in the
filename think about a corresponding ENV-tag, e.g.
"bootloader-grub2-leap15.1" should have "ENV-VERSION-15.1" as well as
"ENV-LEAP-1".

Related progress issue: https://progress.opensuse.org/issues/67006