### PR TITLE
Add needles for grub on Leap 15.1-JeOS

### DIFF
--- a/bootmenu-aarch64-jeos-20190315.json
+++ b/bootmenu-aarch64-jeos-20190315.json
@@ -15,6 +15,7 @@
     "ENV-UEFI-1",
     "ENV-LEAP-1",
     "ENV-VERSION-15.1",
-    "bootloader-grub2"
+    "bootloader-grub2",
+    "grub2"
   ]
 }


### PR DESCRIPTION
Add missing needles to for GRUB on openSUSE Leap 15.1 JeOS