### PR TITLE
Reduce match percentage for inst-rootpassword as cursor causes failure

### DIFF
--- a/user_settings_root-inst-rootpassword-20201220.json
+++ b/user_settings_root-inst-rootpassword-20201220.json
@@ -5,7 +5,8 @@
       "type": "match",
       "xpos": 536,
       "ypos": 248,
-      "width": 227
+      "width": 227,
+      "match": 85
     }
   ],
   "properties": [],


### PR DESCRIPTION
The cursor, when percent in the matching area is causing test failure. Reducing the match percentage to 85% should fix that.

https://openqa.opensuse.org/tests/1714886#step/yast2_firstboot/12