### PR TITLE
ci: Add a retry loop around package installation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,12 +4,18 @@ stages:
   - mirror
 
 mirror-from-github:
+    retry: 2
     stage: mirror
     rules:
           - if: $TOKEN
     before_script:
         - source /etc/os-release && zypper ar http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_${VERSION}/SUSE:CA.repo
-        - zypper -n in git ca-certificates-suse
+        - |
+          for i in {1..3}; do
+              zypper -n in git ca-certificates-suse
+              zypper ref
+              sleep 1
+          done
     script:
         - git config user.email "you@example.com"
         - git config user.name "Your Name"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,8 +12,7 @@ mirror-from-github:
         - source /etc/os-release && zypper ar http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_${VERSION}/SUSE:CA.repo
         - |
           for i in {1..3}; do
-              zypper -n in git ca-certificates-suse
-              zypper ref
+              zypper -n in git ca-certificates-suse && zypper ref && break
               sleep 1
           done
     script:


### PR DESCRIPTION
Also a job-based retry of 2 (the maximum) in case the job fails for other reasons.

This addresses common errors like the following:

- Cannot read input: bad stream or EOF.
- Media source [...] does not contain the desired medium