### PR TITLE
 internal CI: use project scope token to synchronize repository

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ mirror-from-github:
     retry: 2
     stage: mirror
     rules:
-          - if: $CI_JOB_TOKEN
+          - if: $CI_PUSH_TOKEN
     before_script:
         - source /etc/os-release && zypper ar http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_${VERSION}/SUSE:CA.repo
         - |
@@ -20,5 +20,5 @@ mirror-from-github:
         - git config user.name "Your Name"
         - "git remote add github https://github.com/os-autoinst/os-autoinst-needles-opensuse ||:"
         - git fetch github master:gmaster
-        - git remote set-url origin https://gitlab:${CI_JOB_TOKEN}@gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror.git
+        - git remote set-url origin ${CI_SERVER_PROTOCOL}://does_not_matter:${CI_PUSH_TOKEN}@${CI_SERVER_FQDN}/${CI_PROJECT_PATH}.git
         - git push -f origin gmaster:master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ mirror-from-github:
     retry: 2
     stage: mirror
     rules:
-          - if: $TOKEN
+          - if: $CI_JOB_TOKEN
     before_script:
         - source /etc/os-release && zypper ar http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_${VERSION}/SUSE:CA.repo
         - |
@@ -20,5 +20,5 @@ mirror-from-github:
         - git config user.name "Your Name"
         - "git remote add github https://github.com/os-autoinst/os-autoinst-needles-opensuse ||:"
         - git fetch github master:gmaster
-        - git remote set-url origin https://gitlab:${TOKEN}@gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror.git
+        - git remote set-url origin https://gitlab:${CI_JOB_TOKEN}@gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror.git
         - git push -f origin gmaster:master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.opensuse.org/opensuse/leap:latest
+image: registry.opensuse.org/home/okurz/container/ca/containers/tumbleweed:curl-jq-ssh-git
 
 stages:
   - mirror
@@ -8,13 +8,6 @@ mirror-from-github:
     stage: mirror
     rules:
           - if: $CI_PUSH_TOKEN
-    before_script:
-        - source /etc/os-release && zypper ar http://download.suse.de/ibs/SUSE:/CA/openSUSE_Leap_${VERSION}/SUSE:CA.repo
-        - |
-          for i in {1..3}; do
-              zypper -n in git ca-certificates-suse && zypper ref && break
-              sleep 1
-          done
     script:
         - git config user.email "you@example.com"
         - git config user.name "Your Name"


### PR DESCRIPTION
https://gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror/-/merge_requests/2 and https://gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror/-/merge_requests/3 but at the correct place :)

https://progress.opensuse.org/issues/182759#note-6 documents what I already did in this internal repository to make this MR work. I tested most of this on a local fork and we already had a single run where the pipeline destroyed itself: https://gitlab.suse.de/openqa/os-autoinst-needles-opensuse-mirror/-/jobs/4343817 (which paradoxically means, it works as expected)