### PR TITLE
Remove tag opensuse-welcome-show-on-boot from needle

### DIFF
--- a/opensuse-welcome-gnome-20250804.json
+++ b/opensuse-welcome-gnome-20250804.json
@@ -25,7 +25,6 @@
   "properties": [],
   "tags": [
     "ENV-DESKTOP-gnome",
-    "opensuse-welcome",
-    "opensuse-welcome-show-on-boot"
+    "opensuse-welcome"
   ]
 }


### PR DESCRIPTION
The needle created has an extra tag that matches opensuse-welcome-show-on-boot which is wrong in this case

goes together with: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/23006
