### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/os-autoinst/os-autoinst-needles-opensuse/security/code-scanning/1](https://github.com/os-autoinst/os-autoinst-needles-opensuse/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yaml` at the workflow root level, just below the `on:` trigger section and before `jobs:`.  
For this workflow, the minimal and best-fit permission is:

- `contents: read`

This preserves existing functionality (`actions/checkout` and test execution) while ensuring the `GITHUB_TOKEN` is not over-privileged by inherited defaults. No imports, methods, or dependency changes are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
